### PR TITLE
Fix typo, update to latest best practices for pairing

### DIFF
--- a/HueLightBridge.js
+++ b/HueLightBridge.js
@@ -486,10 +486,9 @@ HueLightBridge.prototype._pair_device = function (request, response, native) {
     var account_key = "/bridges/HueLightBridge/" + native.uuid + "/account";
 
     var msgd;
-    if (self.native.modelNumber === '929000226503') {
+    if (native.modelNumber === '929000226503') {
         msgd = {
-            devicetype: "test user",
-            username: account_value
+            devicetype: "test user"
         };
     } else {
         msgd = {


### PR DESCRIPTION
I no longer send the username, per
http://www.developers.meethue.com/documentation/important-whitelist-chan
ges
This eliminates the ‘parameter, username, not available’ error I was
getting when attempting to pair. Note that I updated the hub to the
latest firmware using the latest version of the HUE app…
